### PR TITLE
[gnupg2] Provide systemd socket and service file for gpg-agent.

### DIFF
--- a/rpm/90-gpg-agent.conf
+++ b/rpm/90-gpg-agent.conf
@@ -1,0 +1,1 @@
+GPG_AGENT_INFO=~/.gnupg/S.gpg-agent:0:1

--- a/rpm/gnupg2.spec
+++ b/rpm/gnupg2.spec
@@ -3,10 +3,12 @@ Summary:    Utility for secure communication and data storage
 Version:    2.0.4
 Release:    3
 Epoch:      1
-Group:      Applications/System
 License:    GPLv2+
 URL:        git://git.gnupg.org/gnupg.git
 Source0:    %{name}-%{version}.tar.bz2
+Source1:    gpg-agent.socket
+Source2:    gpg-agent.service
+Source3:    90-gpg-agent.conf
 Patch0:     gnupg-2_0_4-curl_easy_setopt_para_error.patch
 Patch1:     gnupg_bmc5114_cve_2010_2547.patch
 Patch2:     gnupg_sexp_nth_mpi.patch
@@ -16,6 +18,7 @@ BuildRequires:  pkgconfig(libcurl)
 BuildRequires:  pkgconfig(libusb)
 BuildRequires:  pkgconfig(libgcrypt)
 BuildRequires:  pkgconfig(ncurses)
+BuildRequires:  pkgconfig(systemd)
 BuildRequires:  bzip2-devel
 BuildRequires:  gettext
 BuildRequires:  automake
@@ -24,7 +27,8 @@ BuildRequires:  libgpg-error-devel
 BuildRequires:  libksba-devel
 BuildRequires:  pth-devel
 BuildRequires:  zlib-devel
-
+Requires:       systemd
+%{?systemd_requires}
 
 %description
 GnuPG is GNU's tool for secure communication and data storage.  It can
@@ -79,6 +83,11 @@ rm -rf %{buildroot}
 mkdir -p %{buildroot}%{_docdir}/%{name}-%{version}
 install -m0644 -t %{buildroot}%{_docdir}/%{name}-%{version} \
         AUTHORS ChangeLog NEWS README THANKS TODO
+mkdir -p %{buildroot}%{_userunitdir}
+install -m 644 %{SOURCE1} %{buildroot}%{_userunitdir}
+install -m 644 %{SOURCE2} %{buildroot}%{_userunitdir}
+mkdir -p %{buildroot}%{_sharedstatedir}/environment/nemo
+install -m 644 %{SOURCE3} %{buildroot}%{_sharedstatedir}/environment/nemo
 
 %find_lang gnupg2
 
@@ -99,6 +108,8 @@ install -m0644 -t %{buildroot}%{_docdir}/%{name}-%{version} \
 %{_sbindir}/*
 %{_datadir}/gnupg/
 %{_libexecdir}/*
+%{_userunitdir}/gpg-agent.*
+%{_sharedstatedir}/environment/nemo/*.conf
 
 %files doc
 %{_docdir}/%{name}-%{version}

--- a/rpm/gpg-agent.service
+++ b/rpm/gpg-agent.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=GnuPG agent
+Requires=gpg-agent.socket
+
+[Service]
+Type=forking
+ExecStart=/usr/bin/gpg-agent --daemon --use-standard-socket
+ExecReload=/usr/bin/gpgconf --reload gpg-agent
+

--- a/rpm/gpg-agent.socket
+++ b/rpm/gpg-agent.socket
@@ -1,0 +1,12 @@
+[Unit]
+Description=GnuPG agent
+ConditionUser=!root
+
+[Socket]
+ListenStream=%h/.gnupg/S.gpg-agent
+FileDescriptorName=std
+SocketMode=0600
+
+[Install]
+WantedBy=sockets.target
+


### PR DESCRIPTION
Following discussions on sailfishos/sailfish-secrets#178 and sailfishos/pth#1, here is a partial attempt to get a `gpg-agent` running in daemon mode on-demand.

I say partial for two reasons:
- I'm a noob regarding systemd and my new `gpg-agent.socket` from this MR is not started automatically like the PulseAudio one for instance with the user session. I didn't find why. Thus I need to start it by hand for test purposes with `systemctl --user start gpg-agent.socket`,
- the socket is then well handled by systemd and the associated service is started when a program like `gpg-connect-agent` or even `gpg2` is used. But the first operation always hangs forever. I guess this is due to how the agent is coded, not knowing about systemd way to pipe the sockets. It is obviously working for recent versions of GnuPG, but well, you know. That being said, all next operations are then successfull, even from a jailed application.

So to summarize, it may be easier to run the gpg-agent always, and not just on-demand, like that we avoid the failure of the first operation. This is the first solution to get GnuPG operations working in jailed applications (it requires the pth patch also). For reference, the second solution consists of keeping the gpg-agent running in PIPE mode on demand in a transient way for the on-going operation (like asking a passphrase), like it is now. But this second solution requires to move the sailfish-secrets daemon socket to a subdirectory and requires to grant some new Secrets.permission to the GnuPG permissions.

@Thaodan and @pvuorela please feel free to ask other reviewers if you think it's worth discussing the matter.